### PR TITLE
Pk3make include

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pk3make"]
+	path = pk3make
+	url = git@github.com:liquidunderground/pk3make.git


### PR DESCRIPTION
In order to finally build up a proper autobuild system, I've launched [PK3Make](https://github.com/liquidunderground/pk3make) as a separate repository.

This Pull Request includes our PK3Make repository directly as a submodule, avoiding the need to publish it through PyPI during development.