### PR TITLE
Update README.txt build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,25 @@ Sonic Robo Blast 2 in the spirit of Freedoom and LibreQuake.
 
 # BUILDING
 
+## USING PIP
+
+1. Clone the repository: `git clone https://github.com/liquidunderground/total-conversion.git`
+2. Set up Python3
+    1. Install Python
+    2. Set up a [virtual environment] using `python3 -m venv .venv`
+    3. Activate the virtual environment using `. .venv/bin/activate`
+    4. Install PK3Make using `pip install pk3make`
+3. Build the project using `pk3make all`
+
+## USING SUBMODULES
+
 1. Clone the repository: `git clone https://github.com/liquidunderground/total-conversion.git`
 2. Pull in [PK3Make] `git submodule update --init --recursive`
 3. Set up Python3
-    a. Install Python
-    b. Set up a [virtual environment]
-    c. Install PK3Make using `pip install -e pk3make`
+    1. Install Python
+    2. Set up a [virtual environment] using `python3 -m venv .venv`
+    3. Activate the virtual environment using `. .venv/bin/activate`
+    4. Install PK3Make using `pip install -e pk3make`
 4. Build the project using `pk3make all`
 
 [PK3Make]: https://github.com/liquidunderground/pk3make

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Sonic Robo Blast 2 in the spirit of Freedoom and LibreQuake.
 # BUILDING
 
 1. Clone the repository: `git clone https://github.com/liquidunderground/total-conversion.git`
-2. Pull in [PK3Make] `git submodule init --recursive`
+2. Pull in [PK3Make] `git submodule update --init --recursive`
 3. Set up Python3
     a. Install Python
-    b. Install PK3Make's dependencies using `pip install -r requirements.txt`
-    c. Set up a [virtual environment]
-4. Build the project using `python3 pk3make/pk3make.py all`
+    b. Set up a [virtual environment]
+    c. Install PK3Make using `pip install -e pk3make`
+4. Build the project using `pk3make all`
 
 [PK3Make]: https://github.com/liquidunderground/pk3make
 [virtual environment]: https://docs.python.org/3/library/venv.html


### PR DESCRIPTION
The instructions are outdated, the command for updating submodules is `git submodule update --init --recursive` and `pk3make/pk3make.py` doesn't exist, but is rather contained in the virtualenv after installing it.

I also changed it so it uses an editable install when installing pk3make via pip, to make development easier. See here for some more info on this: https://setuptools.pypa.io/en/latest/userguide/development_mode.html